### PR TITLE
add: 로그인_회원가입 페이지 헤더 로고 컴포넌트로 분리

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 // import { authAPI } from '../../services/경로는나중에';
-
+import AuthHeaderLogo from '@/src/components/auth/AuthHeaderLogo'
 interface LoginData {
   email: string;
   password: string;
@@ -71,15 +71,7 @@ export default function Login() {
 
   return (
     <div className='bg-black text-white min-h-screen pt-[100px] pb-[50px]'>
-      <header className='loginHeader mb-[40px]'>
-        <div className='headerInner w-[396px] mx-auto text-center'>
-          <Link href='/'>
-            <h1 className='font-baskin text-[75px]'>
-              최애<span className='text-main'>의</span>포토
-            </h1>
-          </Link>
-        </div>
-      </header>
+      <AuthHeaderLogo title="최애의포토" highlight="의" />
       <div className='loginWrap max-w-[520px] min-w-[350px] mx-auto mb-[50px] w-[60%]'>
         <form
           className='max-w-[500px] flex flex-col items-center'

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 // import { authAPI } from '../../services/경로는나중에';
+import AuthHeaderLogo from '@/src/components/auth/AuthHeaderLogo'
 
 interface SignUpData {
   email: string;
@@ -73,15 +74,7 @@ export default function Signup() {
 
   return (
     <div className='bg-black text-white min-h-screen pt-[100px] pb-[50px]'>
-      <header className='loginHeader mb-[40px]'>
-        <div className='headerInner w-[396px] mx-auto text-center'>
-          <Link href='/'>
-            <h1 className='font-baskin text-[75px]'>
-              최애<span className='text-main'>의</span>포토
-            </h1>
-          </Link>
-        </div>
-      </header>
+      <AuthHeaderLogo title="최애의포토" highlight="의" />
       <div className='loginWrap max-w-[520px] min-w-[350px] mx-auto mb-[50px] w-[60%]'>
         <form
           className='max-w-[500px] flex flex-col items-center'

--- a/src/components/Auth/AuthHeaderLogo.tsx
+++ b/src/components/Auth/AuthHeaderLogo.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+interface HeaderProps {
+  title: string; // 제목 텍스트
+  highlight?: string; // 강조할 단어 (기본값은 빈 문자열)
+}
+
+export default function AuthHeaderLogo({ title, highlight = '' }: HeaderProps) {
+  return (
+    <header className='loginHeader mb-[40px]'>
+      <div className='headerInner w-[396px] mx-auto text-center'>
+        <Link href='/'>
+          <h1 className='font-baskin text-[60px] md:text-[75px]'>
+            {title.split(highlight).map((part, index) => (
+              <span key={index}>
+                {part}
+                {index < title.split(highlight).length - 1 && (
+                  <span className='text-main'>{highlight}</span>
+                )}
+              </span>
+            ))}
+          </h1>
+        </Link>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
로그인_회원가입 페이지 헤더 로고 컴포넌트로 분리
모바일 화면 로고 사이즈 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 및 회원가입 페이지의 헤더 디자인을 개선했습니다.
	- 타이틀과 하이라이트 텍스트를 강조하는 새로운 `AuthHeaderLogo` 컴포넌트를 추가했습니다.

- **스타일**
	- 헤더 컴포넌트의 시각적 표현을 업데이트했습니다.
	- 홈페이지로 연결되는 링크 스타일을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->