### PR TITLE
feat: 나의 판매 포토카드 페이지 무한스크롤 기능 구현

### DIFF
--- a/src/components/common/photoCard/organisms/photoCardDetail/codeExample.ts
+++ b/src/components/common/photoCard/organisms/photoCardDetail/codeExample.ts
@@ -20,7 +20,7 @@ import PhotoCardDetail from '@/src/components/common/photoCard/organisms/photoCa
   if (props.variant === 'mySellingCard')
     code += `
         totalAmount=${props.totalAmount}
-        soldAmount=${props.soldAmount}
+        remainingAmount=${props.remainingAmount}
         tradeGenre="${props.variant === 'mySellingCard' && props.tradeGenre}"
         tradeGrade="${props.tradeGrade}"
         tradeDescription="${props.tradeDescription}"
@@ -32,9 +32,9 @@ import PhotoCardDetail from '@/src/components/common/photoCard/organisms/photoCa
   else if (props.variant === 'othersCard')
     code += `
         totalAmount=${props.totalAmount}
-        soldAmount=${props.soldAmount}
+        remainingAmount=${props.remainingAmount}
         onPurchase=${props.onPurchase} // 구매버튼 클릭 시 실행할 함수
-        maxAmount=${props.totalAmount - props.soldAmount} // totalAmount - soldAmount
+        maxAmount=${props.remainingAmount} // remainingAmount
     />
 \`\`\`
 `;

--- a/src/components/common/photoCard/organisms/photoCardDetail/photoCardDetail.stories.tsx
+++ b/src/components/common/photoCard/organisms/photoCardDetail/photoCardDetail.stories.tsx
@@ -33,7 +33,7 @@ const OthersPhotoCardDetailProps = {
     '우리집 앞마당 사진이에요 멋지죠? 우리집 앞마당 사진이에요 멋지죠? 우리집 앞마당 사진이에요 ',
   price: 4,
   totalAmount: 5,
-  soldAmount: 2,
+  remainingAmount: 2,
   variant: 'othersCard',
 } as PhotoCardDetailProps;
 
@@ -56,7 +56,7 @@ const MyPhotoCardDetailProps = {
     '우리집 앞마당 사진이에요 멋지죠? 우리집 앞마당 사진이에요 멋지죠? 우리집 앞마당 사진이에요 ',
   price: 4,
   totalAmount: 5,
-  soldAmount: 2,
+  remainingAmount: 2,
   variant: 'mySellingCard',
   onDelete: () => console.log(''),
   onEdit: () => console.log(''),
@@ -82,7 +82,7 @@ const MyHoldingPhotoCardDetailProps = {
     '우리집 앞마당 사진이에요 멋지죠? 우리집 앞마당 사진이에요 멋지죠? 우리집 앞마당 사진이에요 ',
   price: 4,
   totalAmount: 5,
-  soldAmount: 2,
+  remainingAmount: 2,
   variant: 'myHoldingCard',
   onSale: () => alert('판매버튼 클릭'),
 } as PhotoCardDetailProps;

--- a/src/components/common/photoCard/organisms/photoCardDetail/photoCardDetail.tsx
+++ b/src/components/common/photoCard/organisms/photoCardDetail/photoCardDetail.tsx
@@ -10,15 +10,15 @@ import MySellingCardDetailSection from './myCardDetailSection';
 import { CommonBtn } from '../../../CommonBtn/CommonBtn';
 
 const RemainingAmount = ({
-  soldAmount,
+  remainingAmount,
   totalAmount,
 }: {
-  soldAmount: number;
+  remainingAmount: number;
   totalAmount: number;
 }) => {
   return (
     <div className='flex gap-[5px]'>
-      {soldAmount}
+      {remainingAmount}
       <span className='text-gray-300 font-light'>/{totalAmount}</span>
     </div>
   );
@@ -35,10 +35,10 @@ export default function PhotoCardDetail(props: PhotoCardDetailProps) {
     description,
     price,
     totalAmount,
-    soldAmount,
+    remainingAmount,
   } = props;
 
-  if (totalAmount < soldAmount) {
+  if (totalAmount < remainingAmount) {
     console.error('판매된 수량은 총 수량보다 클 수 없습니다.');
     return <div>판매된 수량이 총 수량보다 크게 입력되었습니다.</div>;
   }
@@ -94,7 +94,7 @@ export default function PhotoCardDetail(props: PhotoCardDetailProps) {
               ) : (
                 <RemainingAmount
                   totalAmount={totalAmount}
-                  soldAmount={soldAmount}
+                  remainingAmount={remainingAmount}
                 />
               )}
             </CustomLabel>
@@ -102,7 +102,7 @@ export default function PhotoCardDetail(props: PhotoCardDetailProps) {
           {variant === 'othersCard' && (
             <OthersCardDetail
               onPurchase={props.onPurchase}
-              maxAmount={totalAmount - soldAmount}
+              maxAmount={remainingAmount}
               price={price}
             />
           )}

--- a/src/components/common/photoCard/organisms/photoCardDetail/photoCardDetail.types.ts
+++ b/src/components/common/photoCard/organisms/photoCardDetail/photoCardDetail.types.ts
@@ -10,7 +10,7 @@ interface BaseProps {
   nickname: string;
   price: number;
   totalAmount: number;
-  soldAmount: number;
+  remainingAmount: number;
 }
 
 export interface MySellingCardDetailSectionProps {

--- a/src/components/common/photoCard/organisms/photoCardListItem/cardAmountSection.tsx
+++ b/src/components/common/photoCard/organisms/photoCardListItem/cardAmountSection.tsx
@@ -7,7 +7,7 @@ export const CardAmountSection = ({
   price,
   totalAmount,
   headerWeight = 'normal',
-  soldAmount,
+  remainingAmount,
   state,
 }: AmountSectionProps) => {
   return (
@@ -22,15 +22,15 @@ export const CardAmountSection = ({
         <span>{price}P</span>
       </CustomLabel>
       <CustomLabel
-        title={soldAmount && !state ? '잔여' : '수량'}
+        title={remainingAmount && !state ? '잔여' : '수량'}
         titleWeight={headerWeight}
         contentWeight={headerWeight}
         size='small'
         className='text-gray-300'
       >
-        {soldAmount && !state ? (
+        {remainingAmount && !state ? (
           <div className='flex gap-[5px]'>
-            {soldAmount}
+            {remainingAmount}
             <span className='text-gray-300 font-light'>/{totalAmount}</span>
           </div>
         ) : (

--- a/src/components/common/photoCard/organisms/photoCardListItem/codeExample.ts
+++ b/src/components/common/photoCard/organisms/photoCardListItem/codeExample.ts
@@ -18,7 +18,7 @@ import PhotoCardListItem from '@/src/components/common/photoCard/organisms/photo
 
   if (props.variant === 'amount') {
     code += `totalAmount=${props.totalAmount}
-        soldAmount=${props.soldAmount}
+        soldAmount=${props.remainingAmount}
         state="${props.state}"
     />
 \`\`\`

--- a/src/components/common/photoCard/organisms/photoCardListItem/photoCardListItem.tsx
+++ b/src/components/common/photoCard/organisms/photoCardListItem/photoCardListItem.tsx
@@ -18,11 +18,15 @@ export default function PhotoCardListItem(props: PhotoCardListItemProps) {
   const isPrimary = props.variant === 'amount';
   const isSecondary = props.variant === 'trade';
   const isSoldOut =
-    isPrimary && props.totalAmount && props.soldAmount === props.totalAmount;
+    isPrimary && props.totalAmount && props.remainingAmount === 0;
 
-  if (isPrimary && props.soldAmount && props.totalAmount < props.soldAmount) {
-    console.error('판매된 수량은 총 수량보다 클 수 없습니다.');
-    return <div>판매된 수량이 총 수량보다 크게 입력되었습니다.</div>;
+  if (
+    isPrimary &&
+    props.remainingAmount &&
+    props.totalAmount < props.remainingAmount
+  ) {
+    console.error('남은 수량은 총 수량보다 클 수 없습니다.');
+    return <div>남은 수량이 총 수량보다 크게 입력되었습니다.</div>;
   }
 
   return (
@@ -82,7 +86,7 @@ export default function PhotoCardListItem(props: PhotoCardListItemProps) {
         <CardAmountSection
           price={props.price}
           totalAmount={props.totalAmount}
-          soldAmount={props.soldAmount}
+          remainingAmount={props.remainingAmount}
           headerWeight={props.headerWeight}
           state={props.state}
         />

--- a/src/components/common/photoCard/organisms/photoCardListItem/photoCardListItem.types.ts
+++ b/src/components/common/photoCard/organisms/photoCardListItem/photoCardListItem.types.ts
@@ -15,7 +15,7 @@ interface BaseProps {
 export interface AmountSectionProps {
   price: number;
   totalAmount: number;
-  soldAmount?: number;
+  remainingAmount?: number;
   headerWeight?: 'normal' | 'bold';
   state?: CardState;
 }

--- a/src/components/common/photoCard/organisms/photoCardListItem/photocardListItem.stories.tsx
+++ b/src/components/common/photoCard/organisms/photoCardListItem/photocardListItem.stories.tsx
@@ -115,7 +115,7 @@ const MyCardListProps: PhotoCardListItemProps = {
   variant: 'amount',
   totalAmount: 5,
   state: 'exchange',
-  soldAmount: 1,
+  remainingAmount: 1,
   onClick: (id) => alert(id),
 };
 
@@ -136,7 +136,7 @@ const MarketPlaceCardProps: PhotoCardListItemProps = {
   image: defaultPhoto,
   variant: 'amount',
   totalAmount: 5,
-  soldAmount: 5,
+  remainingAmount: 5,
   onClick: (id) => alert(id),
 };
 

--- a/src/components/mySales/page/mySalesPage.tsx
+++ b/src/components/mySales/page/mySalesPage.tsx
@@ -45,6 +45,8 @@ export default function MySalesPage() {
       },
     });
 
+  const allCards = data?.pages.flatMap((page) => page.items) ?? [];
+
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [target] = entries;
@@ -66,9 +68,6 @@ export default function MySalesPage() {
     observer.observe(element);
     return () => observer.disconnect();
   }, [handleObserver]);
-
-  const allCards = data?.pages.flatMap((page) => page.items) ?? [];
-  console.log('data', data?.pages?.[0].items);
 
   const cardsCount = {
     common: total?.items.filter((item: any) => item.grade === 'COMMON').length,

--- a/src/components/mySales/page/mySalesPage.tsx
+++ b/src/components/mySales/page/mySalesPage.tsx
@@ -3,11 +3,11 @@
 import Header from '@/src/components/mySales/header/header';
 import SearchSection from '@/src/components/common/searchSection/searchSection';
 import CardContainer from '@/src/components/mySales/cardContainer/cardContainer';
-import FilterModal from '@/src/components/common/filterModal/templates/filterModal';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { getMySalesCard } from '@/src/services/mySales';
 import useAuthStore from '@/src/store/useAuthStore';
+import { useCallback, useEffect, useRef } from 'react';
 
 export default function MySalesPage() {
   const { user } = useAuthStore();
@@ -21,19 +21,54 @@ export default function MySalesPage() {
     genre: searchParams.get('genre') || undefined,
     stockState: searchParams.get('stockState') || undefined,
     salesMethod: searchParams.get('salesMethod') || undefined,
-    page: Number(searchParams.get('page')) || 1,
-    limit: Number(searchParams.get('size')) || 30,
+    page: Number(searchParams.get('page')),
+    limit: Number(searchParams.get('size')),
   };
+
+  const observerRef = useRef<HTMLDivElement>(null);
 
   const { data: total } = useQuery({
     queryKey: ['mySales', 'total'],
     queryFn: () => getMySalesCard({ page: 1, limit: 30 }),
   });
 
-  const { data } = useQuery({
-    queryKey: ['mySales', query],
-    queryFn: () => getMySalesCard(query),
-  });
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ['mySales', query],
+      queryFn: ({ pageParam }) => getMySalesCard({ ...query, page: pageParam }),
+      initialPageParam: 1,
+      getNextPageParam: (lastPage) => {
+        if (lastPage.meta.page < lastPage.meta.totalPage) {
+          return lastPage.meta.page + 1;
+        }
+        return undefined;
+      },
+    });
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [target] = entries;
+      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage],
+  );
+
+  useEffect(() => {
+    const element = observerRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 0.5,
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [handleObserver]);
+
+  const allCards = data?.pages.flatMap((page) => page.items) ?? [];
+  console.log('data', data?.pages?.[0].items);
 
   const cardsCount = {
     common: total?.items.filter((item: any) => item.grade === 'COMMON').length,
@@ -55,10 +90,14 @@ export default function MySalesPage() {
         variant='mySale'
       />
       <CardContainer
-        cards={data?.items}
+        cards={allCards}
         onClick={(id) => router.push(`marketplace/${id}`)}
       />
-      <FilterModal />
+
+      <div
+        ref={observerRef}
+        className='h-20 flex items-center justify-center'
+      ></div>
     </div>
   );
 }

--- a/src/components/mySales/page/mySalesPage.tsx
+++ b/src/components/mySales/page/mySalesPage.tsx
@@ -21,8 +21,8 @@ export default function MySalesPage() {
     genre: searchParams.get('genre') || undefined,
     stockState: searchParams.get('stockState') || undefined,
     salesMethod: searchParams.get('salesMethod') || undefined,
-    page: Number(searchParams.get('page')),
-    limit: Number(searchParams.get('size')),
+    page: Number(searchParams.get('page')) || 1,
+    limit: Number(searchParams.get('size')) || 30,
   };
 
   const observerRef = useRef<HTMLDivElement>(null);

--- a/src/lib/axios/types/marketplaceMain/mainpagecardType.ts
+++ b/src/lib/axios/types/marketplaceMain/mainpagecardType.ts
@@ -31,7 +31,7 @@ export const mapApiDataToAmountListItem = (data: ApiData): AmountListItem => ({
   image: '/images/sample-image-1.webp',
   fontWeight: 'bold',
   totalAmount: data.totalQuantity || 0,
-  remainingAmount: (data.totalQuantity || 0) - (data.remainingQuantity || 0),
+  remainingAmount: data.remainingQuantity || 0,
   headerWeight: 'normal',
   state: undefined,
   variant: 'amount',

--- a/src/lib/axios/types/marketplaceMain/mainpagecardType.ts
+++ b/src/lib/axios/types/marketplaceMain/mainpagecardType.ts
@@ -31,7 +31,7 @@ export const mapApiDataToAmountListItem = (data: ApiData): AmountListItem => ({
   image: '/images/sample-image-1.webp',
   fontWeight: 'bold',
   totalAmount: data.totalQuantity || 0,
-  soldAmount: (data.totalQuantity || 0) - (data.remainingQuantity || 0),
+  remainingAmount: (data.totalQuantity || 0) - (data.remainingQuantity || 0),
   headerWeight: 'normal',
   state: undefined,
   variant: 'amount',

--- a/src/services/mySales.ts
+++ b/src/services/mySales.ts
@@ -10,13 +10,13 @@ interface MySalesQueryParams {
 }
 
 export const getMySalesCard = async (params: MySalesQueryParams) => {
-  const filteredParams = Object.fromEntries(
-    Object.entries(params).filter(([_, value]) => value !== undefined),
-  );
-
   try {
     const { data } = await axiosInstance.get('/users/my-cards/sales', {
-      params: filteredParams,
+      params: {
+        ...params,
+        page: params.page || 1,
+        limit: params.limit || 30,
+      },
     });
     return data;
   } catch (e: any) {

--- a/src/services/mySales.ts
+++ b/src/services/mySales.ts
@@ -13,7 +13,9 @@ export const getMySalesCard = async (params: MySalesQueryParams) => {
   try {
     const { data } = await axiosInstance.get('/users/my-cards/sales', {
       params: {
-        ...params,
+        ...Object.fromEntries(
+          Object.entries(params).filter(([_, v]) => v !== undefined),
+        ),
         page: params.page || 1,
         limit: params.limit || 30,
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 판매 카드 목록에 무한 스크롤 기능 추가
	- 스크롤 시 자동으로 추가 데이터 로드

- **성능 개선**
	- 페이지네이션 로직 최적화
	- 데이터 로딩 방식 개선
	- 기본 페이지 및 제한 값 설정

- **버그 수정**
	- 데이터 페치 방식 안정성 향상

- **변경 사항**
	- 카드 세부 정보에서 '판매량'을 '남은 수량'으로 변경
	- 카드 세부 정보의 데이터 구조 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->